### PR TITLE
"ListenNoRead" and optimized knx startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -812,7 +812,7 @@ KNXDevice.prototype = {
 				
 			}
 
-			var listenaddressesNoRead = listenaddresses;
+			var listenaddressesToRead = listenaddresses;
 			if ('ListenNoRead' in config) {
 				listenaddresses = listenaddresses.concat(config.ListenNoRead || []); 
 			}
@@ -841,7 +841,7 @@ KNXDevice.prototype = {
 					throw new Error("[ERROR] unknown type passed");
 				} 
 				this.log("["+ this.name +"]:["+myCharacteristic.displayName+"]: Issuing read requests on the KNX bus...");
-				this.knxreadarray(listenaddressesNoRead);
+				this.knxreadarray(listenaddressesToRead);
 			}
 			return myCharacteristic; // for chaining or whatsoever
 		},

--- a/index.js
+++ b/index.js
@@ -811,6 +811,12 @@ KNXDevice.prototype = {
 				listenaddresses = [config.Set].concat(config.Listen || []); // listen to all, even SET addresses 
 				
 			}
+
+			var listenaddressesNoRead = listenaddresses;
+			if ('ListenNoRead' in config) {
+				listenaddresses = listenaddresses.concat(config.ListenNoRead || []); 
+			}
+
 			if (listenaddresses.length>0) {
 				//this.log("Binding LISTEN");
 				// can read
@@ -835,7 +841,7 @@ KNXDevice.prototype = {
 					throw new Error("[ERROR] unknown type passed");
 				} 
 				this.log("["+ this.name +"]:["+myCharacteristic.displayName+"]: Issuing read requests on the KNX bus...");
-				this.knxreadarray(listenaddresses);
+				this.knxreadarray(listenaddressesNoRead);
 			}
 			return myCharacteristic; // for chaining or whatsoever
 		},

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var knxd = require('eibd');
 var Hapi = require('hapi');
 
 var Service, Characteristic; // passed default objects from hap-nodejs
-
+var alreadyScanned;
 
 
 function KNXPlatform(log, config){
@@ -466,6 +466,15 @@ KNXDevice.prototype = {
 			if (!groupAddress) {
 				return null;
 			}
+			if (!alreadyScanned) {
+				alreadyScanned = {};
+			} else {
+				if (alreadyScanned[groupAddress] == true) {
+					this.log("[knxdevice:knxread] group address already scanned "+groupAddress);
+					return null;
+				}
+			}
+			alreadyScanned[groupAddress] = true;
 			this.log("[knxdevice:knxread] preparing knx request for "+groupAddress);
 			var knxdConnection = new knxd.Connection();
 			// this.log("DEBUG in knxread: created empty connection, trying to connect socket to "+this.knxd_ip+":"+this.knxd_port);


### PR DESCRIPTION
if you like you can pull my changes into your branch. i added 2 things:

1. Add a hashmap to track already scanned group addresses in startup phase.
'alreadyScanned' contains a hashmap with all scanned addresses. This
prevents homebridge from reading the same address multiple times.

2. ListenNoRead allows to add listener addresses without reading these
addresses on startup. I use this for all my central addresses because it
makes no sense to read them from the bus. Otherwise the bus responds
with undefined behaviour because multiple devices which listen to this
central addresses will send a response.

"services":[
{
"type":"Lightbulb",
"name":"Stehlampe",
"description":"",
"On":{
"Set":"1/1/50",
"Listen":["1/1/50"],
**"ListenNoRead":["1/0/1"]**
}
}]

have fun.

cheers