### PR TITLE
Fixed OneWaySwitch, "On characteristic" bool format

### DIFF
--- a/lib/addins/OneWaySwitch.js
+++ b/lib/addins/OneWaySwitch.js
@@ -43,7 +43,7 @@ class OneWaySwitch extends HandlerPattern {
 			if (this.timer) {
 				log("Aborting old timer!");
 				clearTimeout(this.timer);
-			} else if (newValue===1){
+			} else if (newValue==1){
 				log("Sending value "+ this.myAPI.getLocalConstant('SwitchSends') || 0 + " to the bus");
 				this.myAPI.knxWrite('On', this.myAPI.getLocalConstant('SwitchSends') || 0); 
 				this.timer = setTimeout(function(field) {


### PR DESCRIPTION
In my case (iOS 10.3.3, latest versions of homebridge and homebridge-knx), the parameter 'newValue' is passed as a Boolean. Thus, the strict comparison always evaluates to false. Changing this to be evaluated as a non strict comparison, the OneWaySwitch works as intended for me.