### PR TITLE
dimmer handler: fix for problem with onHKValueChange () switching off outside timer

### DIFF
--- a/lib/addins/Dimmer.js
+++ b/lib/addins/Dimmer.js
@@ -66,7 +66,13 @@ class Dimmer extends HandlerPattern {
 				this.myAPI.setValue('On', true);	
 				this.myAPI.setValue('Brightness', knxValue);
 			}
-		}
+		} else if (this.lastState===true && field === 'On' && knxValue ===0) {
+			// switching off outside timer
+			this.lastState=false;
+			clearTimeout(this.timer);
+			this.timer = undefined;
+			this.myAPI.setValue('On', false);
+		 } 
 		
 	} // onBusValueChange
 	


### PR DESCRIPTION
it looks like there is an error in dimmer handler.
If you switch on the light over the knx bus (room switch) with the On group address and after that off with the same knx group address the off status is not handled and in the home app the light is still shows as on.