### PR TITLE
Added PulseLight add-in

### DIFF
--- a/lib/addins/PulseLight.js
+++ b/lib/addins/PulseLight.js
@@ -1,0 +1,42 @@
+ /* jshint esversion: 6, strict: true, node: true */
+ 
+'use strict';
+/**
+ * @type {HandlerPattern}
+ */
+var HandlerPattern = require('./handlerpattern.js');
+var log = require('debug')('PulseLight');
+
+/**
+ * @class A custom handler that always sends a 1 to KNX to iterate the same pulse trigger   
+ * @extends HandlerPattern
+ */
+class PulseLight extends HandlerPattern {
+
+	constructor(knxAPI) {
+		super(knxAPI); // call the super constructor first. Always.
+	}
+	
+	/****
+	 * onKNXValueChange is invoked if a Bus value for one of the bound addresses is received
+	 * 
+	 */
+	onKNXValueChange(field, oldValue, knxValue) {
+        var newValue; //Value for Homekit
+        if(field === "On"){
+            if((knxValue? 1:0) !== (oldValue? 1:0)){
+               this.myAPI.setValue('On', newValue);
+            }
+       }
+	} // onBusValueChange
+	
+	/****
+	 * onHKValueChange is invoked if HomeKit is changing characteristic values
+	 * 
+	 */
+	onHKValueChange(field, oldValue, newValue) {
+		log('INFO: onHKValueChange(' + field + ", "+ oldValue + ", "+ newValue + ")");
+		this.myAPI.knxWrite(field, 1);
+	} // onHKValueChange
+} // class	
+module.exports = PulseLight;


### PR DESCRIPTION
I needed a custom add-in for a lightbulb that should be able to be turned on/off in Homekit but always sends a value of 1 to KNX. This is because I simulate pushing a button on a 433Mhz remote to turn on / off my lights for the hood of my kitchen. The PulseLight does exactly this. Since it is not possible to read any status I didn't include this in PulseLight. This means that Homekit is responsible for remembering the state.