### PR TITLE
Initialization hooks for custom Handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ notes.txt
 .tern-project
 .project
 .CHANGELOG.md.html
+*.njsproj
+.vs/homebridge-knx/v15/.suo
+*.sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for Version 0.3.x
 
+## DEV
+- new call hooks for custom handlers. Invented by [ctschach](https://github.com/ctschach/homebridge-knx/commit/5829bf2a1ccf2fa34e37b4d55d87c763a0d5e786), the custom handlers now get informed when the service is ready 
+  - `onServiceInit()`  
+  and when all devices are loaded and initialized
+  - `onHomeKitReady()`
+
+
 
 ## 0.3.16
 - bugfix for a scaling issue with the new handler in 0.3.15

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ ECMA-Script 2015 (6.0) Language required
 'use strict';
 
 
-var AccConstructor = require('./lib/knxdevice.js');
+var KNXDevice = require('./lib/knxdevice.js');
 var userOpts = require('./lib/user').User;
 var Service, Characteristic; // passed default objects from hap-nodejs
 var globs = {}; // the storage for cross module data pooling;
@@ -213,11 +213,11 @@ KNXPlatform.prototype.configure = function() {
 			globs.debug('Matched an accessory: ' + currAcc.DeviceName + ' === ' + matchAcc.displayName);
 			// Instantiate and pass the existing platformAccessory
 			matchAcc.active = true;
-			globs.devices.push(new AccConstructor(globs, foundAccessories[int], matchAcc));
+			globs.devices.push(new KNXDevice(globs, foundAccessories[int], matchAcc));
 		} else {
 			// this one is new
 			globs.debug('New accessory found: ' + currAcc.DeviceName);
-			globs.devices.push(new AccConstructor(globs, foundAccessories[int]));
+			globs.devices.push(new KNXDevice(globs, foundAccessories[int]));
 		}
 		// do not construct here: var acc = new accConstructor(globs,foundAccessories[int]);
 
@@ -230,7 +230,26 @@ KNXPlatform.prototype.configure = function() {
 	globs.info('Saving config file!');
 	userOpts.storeConfig();
 	
-	
+
+    // here needs the hook for global "finished" event to go into
+
+    for (var i = 0; i < globs.devices.length; i++) {
+        matchAcc = globs.devices[i];
+        for (var i_serv = 0; i_serv < matchAcc.services.length; i_serv++) {
+            var myKNXService = matchAcc.services[i_serv];
+            if (myKNXService.customServiceAPI && myKNXService.customServiceAPI.handler) {
+                if (typeof myKNXService.customServiceAPI.handler.onHomeKitReady === 'function') {
+                    this.globs.debug(matchAcc.name + "/" + myKNXService.name +": Custom Handler onHomeKitReady()");
+                    myKNXService.customServiceAPI.handler.onHomeKitReady();
+                }
+            }
+        }
+
+    }
+
+    //TODO: Inform all devices that homekit has now finished loading
+
+
 	/*********************************************************************************/
 	// start the tiny web server for deleting orphaned devices
 	globs.debug('BEFORE http.createServer');

--- a/lib/addins/handlerpattern.js
+++ b/lib/addins/handlerpattern.js
@@ -29,7 +29,28 @@ class HandlerPattern {
 	onHKValueChange(field, oldValue, newValue) {
 		throw new Error('IMPLEMENTATION MISSING.');
 		
-	} // onHKValueChange
+    } // onHKValueChange
+
+    /****
+     * onServiceInit() is invoked when the service is done initializing in HomeKit - however, other Devices/Services are not necessarily finished.
+     * Based on ctschach's code in https://github.com/ctschach/homebridge-knx/commit/5829bf2a1ccf2fa34e37b4d55d87c763a0d5e786
+     * */
+    onServiceInit() {
+        // optional
+
+    }
+
+
+    /****
+     * onHomeKitReady() is invoked after ALL devices are initiated in HomeKit and HomeKit starts normal operation
+     * */
+    onHomeKitReady() {
+        // optional
+    }
+
+  
+
+
 } // class	
 	
 module.exports = HandlerPattern;	

--- a/lib/knxdevice.js
+++ b/lib/knxdevice.js
@@ -107,7 +107,17 @@ class KNXDevice {
 				// everything went fine!
 				this.globs.debug("KNX Service created");
 				this.services.push(myKNXService);
-				accessoryServices.push(myKNXService.getHomeKitService());
+                accessoryServices.push(myKNXService.getHomeKitService());
+                // the service is now successfully initialized
+                // (c) ctschach in https://github.com/ctschach/homebridge-knx/commit/5829bf2a1ccf2fa34e37b4d55d87c763a0d5e786
+                // changes: instead of onHKInit() now call onServiceInit()
+                // Let's check if we have a customHandler in this service and run the onHKInit function in case this exists
+                if (myKNXService.customServiceAPI && myKNXService.customServiceAPI.handler) {
+                    if (typeof myKNXService.customServiceAPI.handler.onServiceInit === 'function') {
+                        this.globs.debug("Custom Handler onServiceInit()");
+                        myKNXService.customServiceAPI.handler.onServiceInit();
+                    }
+                }
 			} // if-else
 	
 		} //for


### PR DESCRIPTION
New call hooks for custom handlers. Invented by [ctschach](https://github.com/ctschach/homebridge-knx/commit/5829bf2a1ccf2fa34e37b4d55d87c763a0d5e786), the custom handlers now get informed 

1. when the service is ready 
     - `onServiceInit()`    
1. and when all devices are loaded and initialized  
      - `onHomeKitReady()`  

