### PR TITLE
Neuer KNXSceneSelectorSwitch Handler AddIn

### DIFF
--- a/knx_config.json.md
+++ b/knx_config.json.md
@@ -18,13 +18,13 @@ homebridge-knx expects the following structure in the `knx_config.json`:
 
 `Devices` is an array of objects, each representing an *homekit accessory*. 
 
-#Devices
+# Devices  
 `Devices` must have a unique `DeviceName`. The name cannot be changed in the config file after pairing with homekit, because homekit *copies* it into its database. You can change the name of the device in homekit afterwards; unless you erase your home or un-pair homebridge it will keep the changed name.  
 In Apple's `Home` app (or other homekit enabled apps) devices can get assigned to rooms.
 
 Each device needs a section `Services`. Here all functionality of the device is defined.
 
-#Services
+# Services  
 `Services` again is an array of objects, each representing a *homekit service*.  
 Each service **must** have:
 - a unique `ServiceName` (regarding changing names in a paired instance [see Devices](#devices) )
@@ -39,7 +39,7 @@ Service types are regularly amended by Apple, to get new service types into home
 There is a Javascript file containing all valid services and characteristics located here: https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js
 
  
-##Characteristics
+## Characteristics  
 Each characteristic is an object containing at least a `Type` field. Types can be "On" for power, "Brightness" for dimmable lights etc.  
 Characteristics **can** have assigned group addresses in the `Set` and `Listen` arrays.
 For the group addresses it is possible to define a *data point type* `DPT` (currently valid are DPT1, DPT5, DPT5.001, DPT9).  
@@ -47,25 +47,25 @@ For boolean and percentage types it is possible to *reverse* the read/write valu
 
 Characteristics without group addresses can only be used by a `handler`
 
-##Handler
+## Handler  
 New in version 0.3 of homebridge-knx is a little add-in concept, allowing additional functionality to be added without changing the big mass of the code.  
 `handler`s are defined as javascript files in `/lib/addins` and need to [follow some restrictions.](https://github.com/snowdd1/homebridge-knx/blob/plugin-2.0/handler-add-in.md)  
 To assign a handler to a service the **Handler** keyword is used, see example below.  
 Handlers cannot use the `Reverse` keyword for DPT1 and DPT5.001 types, this has to be taken care in the handler's programming.  
 
-##KNXObjects
+## KNXObjects  
 Handlers can make use of KNX group addresses that are not connected directly to characteristics. To allow references to those addresses, they are defined as if they were characteristics. 
 - The `Type` field is a freely definable name field (uniqueness within the service required). 
 - Definition of `DPT` **is mandatory** as the data point type cannot be inferred from a homekit characteristic!  
 
-##LocalConstants
+## LocalConstants
 Handlers can use service-local constants in their code. This allows using the same handler for alike-but-not-equal use cases. The values from the `LocalConstants` can be used in the handler code. This allows re-using the same handler for multiple objects that differ by more than group addresses.
 
 ## UUID and subtype
 homebridge-knx creates a unique UUID for each device newly discovered in the *knx_config.json* and writes that back to the file. Similar, a unique `subtype` field is created for each service.  
 **Do not alter these fields** unless you want to force homebridge-knx to accept this as a **new** device or service, rendering the old one stale and unreachable.
 
-#Example
+# Example
 ```
 {
     "knxd_ip": "192.168.178.100",


### PR DESCRIPTION
Zum direkten Auslösen von KNX-Szenen habe ich den OneWaySwitch kopiert und modifiziert. Es wird eine interne Umrechnung zu DPT17.001 gemacht. Funktioniert bei mir prima ohne weitere Logik auf KNX-Seite. Keine Ahnung, wie ich dies in die Auswahl für die nächste Version bringen kann, daher versuche ich es mal als Issue mit der Datei.
[KNXSceneSelectorSwitch.js.txt](https://github.com/snowdd1/homebridge-knx/files/5597090/KNXSceneSelectorSwitch.js.txt)

