### PR TITLE
Update WindowCoveringTilt.js

### DIFF
--- a/lib/addins/WindowCoveringTilt.js
+++ b/lib/addins/WindowCoveringTilt.js
@@ -172,7 +172,7 @@ class WindowCoveringTilt extends HandlerPattern {
 			var ninetyDegRotation = this.myAPI.getLocalConstant("ninetyDegRotation");
 
 			// is the Shutter one with a full rotation or one with 90° only?
-			if (ninetyDegRotation) {		
+			if (ninetyDegRotation === true) {		
 				if (newValue > 0){
 					knxValue = newValue/90 * 255;
 				} else {


### PR DESCRIPTION
In line 175 JavaScript is testing if the Object ninetyDegRotation exists. But it should test if it is set to "true". 