### PR TITLE
Fix compatibility with Homebridge 2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ function KNXPlatform(log, config, newAPI) {
     globs.knxd = this.config.knxd;
     globs.knxd_ip = this.config.knxd_ip;
     globs.knxd_port = this.config.knxd_port || 6720;
+    globs.knxconnection = this.config.knxconnection;
     globs.log = log;
     globs.knxmonitor = knxmonitor;
     /**

--- a/index.js
+++ b/index.js
@@ -161,7 +161,11 @@ KNXPlatform.prototype.configureAccessory = function (accessory) {
     // set the accessory to reachable if plugin can currently process the accessory
     // otherwise set to false and update the reachability later by invoking
     // accessory.updateReachability()
-    accessory.updateReachability(false);
+    // updateReachability() was removed in Homebridge 2.0, guard for older versions only.
+    // https://github.com/snowdd1/homebridge-knx/issues/218
+    if (typeof accessory.updateReachability === 'function') {
+        accessory.updateReachability(false);
+    }
 
     // collect the accessories
     globs.restoredAccessories.push(accessory);

--- a/lib/characteristic-knx.js
+++ b/lib/characteristic-knx.js
@@ -6,6 +6,7 @@
 
 var iterate = require('./iterate');
 var knxAccess = require('./knxaccess.js');
+var hapConstants = require('./hapConstants');
 
 /**
  * CharacteristicKNX is the wrapper for HomeKit charcteristics with everything needed for KNX use
@@ -79,7 +80,7 @@ class CharacteristicKNX {
             }
         }
         // the following types can have arrays of valid integer values
-        if (this.chr.props.format === this.globs.Characteristic.Formats.UINT8 || this.chr.props.format === this.globs.Characteristic.Formats.INT) {
+        if (this.chr.props.format === hapConstants.Formats.UINT8 || this.chr.props.format === hapConstants.Formats.INT) {
             if (this.config.ValidValues != undefined) // evil twin required for comparing with undefined
             {
                 this.chr.props.validValues = this.config.ValidValues;
@@ -91,7 +92,7 @@ class CharacteristicKNX {
 
 
         // if the characteristic is writable (that is, from homekit to the KNX bus) AND we have a Set section in the config...
-        if (this.chr.props.perms.indexOf(this.globs.Characteristic.Perms.WRITE) > -1) {
+        if (this.chr.props.perms.indexOf(hapConstants.Perms.WRITE) > -1) {
             if (this.config.Set) {
                 // add the group addresses to the set-ga list
                 // register the default handler
@@ -138,7 +139,7 @@ class CharacteristicKNX {
             }
         } // writable
         // if it is readable AND we have a listen section in the config
-        if (this.chr.props.perms.indexOf(this.globs.Characteristic.Perms.READ) > -1) {
+        if (this.chr.props.perms.indexOf(hapConstants.Perms.READ) > -1) {
             if (this.config.Listen) {
 
                 if (!Array.isArray(this.config.Listen)) {
@@ -215,33 +216,33 @@ class CharacteristicKNX {
         if (this.config.DPT) {
             return this.config.DPT;
         } else {
-            if (this.chr.props.format === this.globs.Characteristic.Formats.BOOL) {
+            if (this.chr.props.format === hapConstants.Formats.BOOL) {
                 // found boolean, assume DPT1
                 return "DPT1";
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.INT) {
+            if (this.chr.props.format === hapConstants.Formats.INT) {
                 // found INT, assume DPT5, unless props.unit is Units.PERCENTAGE
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT5";
                 }
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.UINT8) {
+            if (this.chr.props.format === hapConstants.Formats.UINT8) {
                 // found INT, assume DPT5 unless its percentage in UNIT
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT5";
                 }
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.PERCENTAGE) {
+            if (this.chr.props.format === hapConstants.Formats.PERCENTAGE) {
                 // found PERC, assume DPT5.001
                 return "DPT5.001";
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.FLOAT) {
+            if (this.chr.props.format === hapConstants.Formats.FLOAT) {
                 // found FLOAT, assume DPT9 unless its PERCENTAGE in UNIT
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT9";

--- a/lib/customtypes/knxthermostat.js
+++ b/lib/customtypes/knxthermostat.js
@@ -4,33 +4,38 @@
 /* jshint esversion: 6, strict: true, node: true */
 'use strict';
 
-var inherits = require('util').inherits;
+var hapConstants = require('../hapConstants');
 var log = require('debug')('KNXThermostat custom service/characteristic');
 
-/** 
+/**
  *  @param {homebridge/lib/api~API} API
  */
 module.exports = function(API) {
 
-	
+
 	// we are going to extend API.hap.Characteristic and API.hap.Service
 
 	var Characteristic = API.hap.Characteristic;
 	var Service = API.hap.Service;
 
-	Characteristic.KNXThermAtHome = function() {
-		Characteristic.call(this, 'At Home', '00001025-0000-1000-8000-0026BB765292');
-		this.setProps({
-			format : Characteristic.Formats.BOOL,
-			perms : [
-				Characteristic.Perms.READ,
-				Characteristic.Perms.WRITE,
-				Characteristic.Perms.NOTIFY ]
-		});
-		this.value = this.getDefaultValue();
-	};
-	inherits(Characteristic.KNXThermAtHome, Characteristic);
-	Characteristic.KNXThermAtHome.UUID = '00001025-0000-1000-8000-0026BB765292';
+	// newer hap-nodejs versions (Homebridge 2.0+) require ES6 class inheritance instead
+	// of the old Characteristic.call() / util.inherits() pattern.
+	// https://github.com/snowdd1/homebridge-knx/issues/218
+	class KNXThermAtHome extends Characteristic {
+		constructor() {
+			super('At Home', '00001025-0000-1000-8000-0026BB765292');
+			this.setProps({
+				format : hapConstants.Formats.BOOL,
+				perms : [
+					hapConstants.Perms.READ,
+					hapConstants.Perms.WRITE,
+					hapConstants.Perms.NOTIFY ]
+			});
+			this.value = this.getDefaultValue();
+		}
+	}
+	KNXThermAtHome.UUID = '00001025-0000-1000-8000-0026BB765292';
+	Characteristic.KNXThermAtHome = KNXThermAtHome;
 
 	log('Done');
 };

--- a/lib/groupaddress.js
+++ b/lib/groupaddress.js
@@ -1,5 +1,6 @@
 /* jshint esversion: 6, strict: true, node: true */
 'use strict';
+var hapConstants = require('./hapConstants');
 /**
  * Model for KNX group addresses
  * 
@@ -88,11 +89,11 @@ var gaComplete = function(address, globs, Characteristic){
 	// look for the address in the global group address list
 	if (!globs.config.GroupAddresses[address]) {
 		globs.log("The Group Address " + address + " is not yet defined. Type testing is not supported. Assuming match to HomeKit type");
-		if (Characteristic.props.format === globs.Characteristic.Formats.BOOL) {
+		if (Characteristic.props.format === hapConstants.Formats.BOOL) {
 			// Boolean
 			return new GroupAddress(address, 'automatically generated', DPTTypes.DPT1, true, true, true, 'INITIAL')
-		} else if (Characteristic.props.format === globs.Characteristic.Formats.INT || Characteristic.props.format === globs.Characteristic.Formats.UINT8) {
-			if (Characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+		} else if (Characteristic.props.format === hapConstants.Formats.INT || Characteristic.props.format === hapConstants.Formats.UINT8) {
+			if (Characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 				// percentage
 				return new GroupAddress(address, 'automatically generated', DPTTypes['DPT5.001'], true, true, true, 'INITIAL');
 			} else {
@@ -100,7 +101,7 @@ var gaComplete = function(address, globs, Characteristic){
 				return new GroupAddress(address, 'automatically generated', DPTTypes.DPT5, true, true, true, 'INITIAL');
 			}
 
-		} else if (Characteristic.props.format === globs.Characteristic.Formats.FLOAT) {
+		} else if (Characteristic.props.format === hapConstants.Formats.FLOAT) {
 			return new GroupAddress(address, 'automatically generated', DPTTypes.DPT9, true, true, true, 'INITIAL')
 		}
 	} else {

--- a/lib/hapConstants.js
+++ b/lib/hapConstants.js
@@ -1,0 +1,43 @@
+/* jshint esversion: 6, strict: true, node: true */
+'use strict';
+/**
+ * Newer hap-nodejs versions (bundled with Homebridge 2.0+) no longer expose
+ * Characteristic.Formats / .Perms / .Units as static properties. These values
+ * are stable HAP protocol string constants, so we keep our own copy here
+ * instead of depending on the Characteristic object exposing them.
+ *
+ * https://github.com/snowdd1/homebridge-knx/issues/218
+ */
+module.exports = {
+	Formats: {
+		BOOL: 'bool',
+		UINT8: 'uint8',
+		UINT16: 'uint16',
+		UINT32: 'uint32',
+		UINT64: 'uint64',
+		INT: 'int',
+		FLOAT: 'float',
+		STRING: 'string',
+		TLV8: 'tlv8',
+		DATA: 'data',
+		ARRAY: 'array',
+		DICTIONARY: 'dictionary'
+	},
+	Perms: {
+		READ: 'pr',
+		WRITE: 'pw',
+		NOTIFY: 'ev',
+		HIDDEN: 'hd',
+		ADDITIONAL_AUTHORIZATION: 'aa',
+		WRITE_RESPONSE: 'wr',
+		TIMED_WRITE: 'tw'
+	},
+	Units: {
+		CELSIUS: 'celsius',
+		FAHRENHEIT: 'fahrenheit',
+		PERCENTAGE: 'percentage',
+		ARC_DEGREE: 'arcdegrees',
+		LUX: 'lux',
+		SECONDS: 'seconds'
+	}
+};

--- a/lib/knxaccess.js
+++ b/lib/knxaccess.js
@@ -10,6 +10,7 @@ var globs;
 var knx  = require('knx');
 var knxd = require('eibd');
 var iterate = require('./iterate');
+var hapConstants = require('./hapConstants');
 var allFunctions =  {};
 // all purpose / all types write function	
 
@@ -321,20 +322,20 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		TLV8: 'tlv8'
 		}
 	 */
-	case globs.Characteristic.Formats.BOOL:
+	case hapConstants.Formats.BOOL:
 		// boolean is good for any trueish expression from value
 		globs.debug("BOOL:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type );
 		//characteristic.setValue(val ? (reverse ? 0 : 1) : (reverse ? 1 : 0), undefined, 'fromKNXBus');
 		returnValue = val ? (reverse ? 0 : 1) : (reverse ? 1 : 0);
 		break;
-	case globs.Characteristic.Formats.INT:
+	case hapConstants.Formats.INT:
 		// let fall through
-	case globs.Characteristic.Formats.UINT8:
+	case hapConstants.Formats.UINT8:
 		// let fall through
-	case globs.Characteristic.Formats.UINT16:
+	case hapConstants.Formats.UINT16:
 		// let fall through 
 		//fixes #123 
-	case globs.Characteristic.Formats.UINT32:
+	case hapConstants.Formats.UINT32:
 		// fixes #123
 		// to an INT we can assume that the min and max values are set, or a list of allowed values is supplied
 		globs.debug("INT:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type );
@@ -351,7 +352,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		} else {
 
 			// we have a defined range. If it's a percentage, we want to convert the bus value to the spectrum
-			if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+			if (characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 				if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
 					if (type === 'DPT5') {
 						val = reverse ? (255 - val) : val;
@@ -375,12 +376,12 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		}
 
 		break;
-	case globs.Characteristic.Formats.FLOAT:
+	case hapConstants.Formats.FLOAT:
 		globs.debug("FLOAT:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type + " for " +
 				characteristic.displayName);
 
 		// If it's a percentage, we want to convert the bus value to the spectrum
-		if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+		if (characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 			if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
 				if (type === 'DPT5') {
 					val = reverse ? (255 - val) : val;

--- a/lib/knxaccess.js
+++ b/lib/knxaccess.js
@@ -25,7 +25,7 @@ allFunctions.knxwrite = function(callback, groupAddress, dpt, value) {
 	//globs.info("DEBUG in knxwrite");
 	/** @type {eibd~Connection} */
 
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// use KNX JS for KNX IP
 		var connection = knx.Connection({
 			handlers: {
@@ -110,7 +110,7 @@ allFunctions.setPercentage = function(value, callback, gaddress, reverseflag) {
 
 	var numericValue = 0;
 	value = (value >= 0 ? (value <= 100 ? value : 100) : 0); //ensure range 0..100
-	if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+	if (globs.knxconnection === 'knxjs') {
 		numericValue = reverseflag ? 100 - value : value;
 	} else {
 		if (reverseflag) {
@@ -165,7 +165,7 @@ allFunctions.knxread = function(groupAddress) {
 	globs.debug("[knxdevice:knxread] preparing knx request for " + groupAddress);
 
 	// new knxconnection syntax, might fix #164
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// use KNX JS for KNX IP
 		var connection = knx.Connection({
 			handlers: {
@@ -352,7 +352,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 
 			// we have a defined range. If it's a percentage, we want to convert the bus value to the spectrum
 			if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
-				if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+				if (globs.knxconnection === 'knxjs') {
 					if (type === 'DPT5') {
 						val = reverse ? (255 - val) : val;
 					} else if (type === 'DPT5.001') {
@@ -381,7 +381,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 
 		// If it's a percentage, we want to convert the bus value to the spectrum
 		if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
-			if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+			if (globs.knxconnection === 'knxjs') {
 				if (type === 'DPT5') {
 					val = reverse ? (255 - val) : val;
 				} else if (type === 'DPT5.001') {

--- a/lib/knxdevice.js
+++ b/lib/knxdevice.js
@@ -127,7 +127,11 @@ class KNXDevice {
 			globs.API.registerPlatformAccessories("homebridge-knx", "KNX", [this.platformAccessory]);
 		} // if
 		// otherwise we were fine before.
-		this.platformAccessory.updateReachability(true);
+		// updateReachability() was removed in Homebridge 2.0, guard for older versions only.
+		// https://github.com/snowdd1/homebridge-knx/issues/218
+		if (typeof this.platformAccessory.updateReachability === 'function') {
+			this.platformAccessory.updateReachability(true);
+		}
 	} // constructor
 	
 	/**

--- a/lib/knxmonitor.js
+++ b/lib/knxmonitor.js
@@ -34,7 +34,7 @@ function groupsocketlisten(opts, callback) {
 
 var registerSingleGA = function registerSingleGA (groupAddress, dpt, callback) {
 	globs.debug("INFO registerSingleGA "+ groupAddress);
-	if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+	if (globs.knxconnection === 'knxjs') {
 		var dp = new knx.Datapoint({ ga: groupAddress, dpt: dpt, autoread: true });
 		dp.on('event', function (event, value) {
 			if (value != undefined) {
@@ -61,7 +61,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 		return null;
 	}
 
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// using knxjs
 		var connection = knx.Connection({
 			handlers: {

--- a/lib/service-knx.js
+++ b/lib/service-knx.js
@@ -111,8 +111,14 @@ class ServiceKNX {
 		}
 
 		// try to find it.
+		// Homebridge 2.0+ renamed getServiceByUUIDAndSubType() to getServiceById().
+		// https://github.com/snowdd1/homebridge-knx/issues/218
 		/** @type {Service} */
-		this.serviceHK = platformAccessory.getServiceByUUIDAndSubType(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		if (platformAccessory.getServiceById) {
+			this.serviceHK = platformAccessory.getServiceById(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		} else {
+			this.serviceHK = platformAccessory.getServiceByUUIDAndSubType(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		}
 
 
 		if (!this.serviceHK) {


### PR DESCRIPTION
## Summary

Fixes the crashes reported in #218 when running homebridge-knx on Homebridge 2.0. Homebridge 2.0 bundles a newer hap-nodejs that removed/changed a few APIs this plugin relied on:

- `Characteristic` is now an ES6 class, so the ES5 `Characteristic.call()` + `util.inherits()` pattern in the custom `KNXThermAtHome` characteristic (`lib/customtypes/knxthermostat.js`) threw `TypeError: Class constructor cannot be invoked without 'new'`. Rewritten as a proper `class KNXThermAtHome extends Characteristic`.
- `Characteristic.Formats` / `.Perms` / `.Units` are no longer exposed as static properties on `Characteristic`. These are stable HAP protocol string constants, so they're now sourced from a new `lib/hapConstants.js` module instead of being read off the (now incompatible) `Characteristic` object at runtime. Updated `lib/characteristic-knx.js`, `lib/knxaccess.js`, and `lib/groupaddress.js` accordingly.
- `platformAccessory.getServiceByUUIDAndSubType()` was renamed to `getServiceById()`. `lib/service-knx.js` now prefers the new method and falls back to the old one when it isn't available, so both old and new Homebridge versions keep working.
- `accessory.updateReachability()` was removed. Calls in `index.js` and `lib/knxdevice.js` are now guarded with a feature check.

These changes are backwards compatible with older Homebridge versions (feature-detected where the API differs), so no `engines.homebridge` version bump is needed.

Credit to @HolyGiraffe for identifying the root causes and writing up a working patch guide in #218, which this PR is based on (reimplemented as in-repo code changes rather than post-install `sed` patches).

## Test plan

- [x] `node --check` on all touched files
- [ ] Manual smoke test against a running Homebridge 2.0 instance (reported working by @ants83 in #218 using the patch guide this PR implements)

Fixes #218