### PR TITLE
Fix knxjs connection mode never being used

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ function KNXPlatform(log, config, newAPI) {
     globs.knxd = this.config.knxd;
     globs.knxd_ip = this.config.knxd_ip;
     globs.knxd_port = this.config.knxd_port || 6720;
+    globs.knxconnection = this.config.knxconnection;
     globs.log = log;
     globs.knxmonitor = knxmonitor;
     /**

--- a/lib/knxaccess.js
+++ b/lib/knxaccess.js
@@ -25,7 +25,7 @@ allFunctions.knxwrite = function(callback, groupAddress, dpt, value) {
 	//globs.info("DEBUG in knxwrite");
 	/** @type {eibd~Connection} */
 
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// use KNX JS for KNX IP
 		var connection = knx.Connection({
 			handlers: {
@@ -110,7 +110,7 @@ allFunctions.setPercentage = function(value, callback, gaddress, reverseflag) {
 
 	var numericValue = 0;
 	value = (value >= 0 ? (value <= 100 ? value : 100) : 0); //ensure range 0..100
-	if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+	if (globs.knxconnection === 'knxjs') {
 		numericValue = reverseflag ? 100 - value : value;
 	} else {
 		if (reverseflag) {
@@ -165,7 +165,7 @@ allFunctions.knxread = function(groupAddress) {
 	globs.debug("[knxdevice:knxread] preparing knx request for " + groupAddress);
 
 	// new knxconnection syntax, might fix #164
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// use KNX JS for KNX IP
 		var connection = knx.Connection({
 			handlers: {
@@ -352,7 +352,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 
 			// we have a defined range. If it's a percentage, we want to convert the bus value to the spectrum
 			if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
-				if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+				if (globs.knxconnection === 'knxjs') {
 					if (type === 'DPT5') {
 						val = reverse ? (255 - val) : val;
 					} else if (type === 'DPT5.001') {
@@ -381,7 +381,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 
 		// If it's a percentage, we want to convert the bus value to the spectrum
 		if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
-			if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+			if (globs.knxconnection === 'knxjs') {
 				if (type === 'DPT5') {
 					val = reverse ? (255 - val) : val;
 				} else if (type === 'DPT5.001') {

--- a/lib/knxmonitor.js
+++ b/lib/knxmonitor.js
@@ -34,7 +34,7 @@ function groupsocketlisten(opts, callback) {
 
 var registerSingleGA = function registerSingleGA (groupAddress, dpt, callback) {
 	globs.debug("INFO registerSingleGA "+ groupAddress);
-	if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
+	if (globs.knxconnection === 'knxjs') {
 		var dp = new knx.Datapoint({ ga: groupAddress, dpt: dpt, autoread: true });
 		dp.on('event', function (event, value) {
 			if (value != undefined) {
@@ -61,7 +61,7 @@ var startMonitor = function startMonitor(opts) {  // using { host: name-ip, port
 		return null;
 	}
 
-	if(!(!globs.knxconnection) || globs.knxconnection==='knxjs') {
+	if(globs.knxconnection === 'knxjs') {
 		// using knxjs
 		var connection = knx.Connection({
 			handlers: {


### PR DESCRIPTION
## Summary

Fixes #186. `globs.knxconnection` was never populated from the user's `knx_config.json` `knxconnection` setting — it's simply missing from the list of `globs.knxd*`/`globs.config` assignments in `index.js`. So it was always `undefined` at runtime, no matter what a user configured.

Every "use knxjs vs. knxd/eibd" check in `lib/knxaccess.js` and `lib/knxmonitor.js` uses this pattern:

```js
if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs')
```

Two independent bugs compound here:

1. Since `globs.knxconnection` was always `undefined`, this always evaluated to `false`, silently falling back to the `knxd`/`eibd` connection path — regardless of `"knxconnection": "knxjs"` in the config. This matches exactly what @gartlehnerphilipp reported in #186 (Wireshark confirms KNXnet/IP routing traffic is present, i.e. `knxjs` should be usable, yet the plugin still throws `Cannot reach knxd or eibd service`).
2. Even with the value populated, the check itself is wrong: `!(!x) || x === 'knxjs'` reduces to just `Boolean(x)` — any truthy `knxconnection` value (not just `'knxjs'`) would select the knxjs path. That contradicts the documented behavior in `knx_config.json.md` ("set to any other value ... will default to knxd"). The correct pattern already exists elsewhere in the codebase (`lib/customServiceAPI.js:365`: `!knxconnection || knxconnection !== 'knxjs'`, i.e. "not knxjs"), which this PR now matches consistently everywhere by simplifying every occurrence to `globs.knxconnection === 'knxjs'`.

## Changes

- `index.js`: add the missing `globs.knxconnection = this.config.knxconnection;` assignment.
- `lib/knxaccess.js` (5 occurrences) and `lib/knxmonitor.js` (2 occurrences): simplify the inverted/redundant condition to `globs.knxconnection === 'knxjs'`.

## Test plan

- [x] `node --check` on all touched files
- [ ] Manual smoke test with `"knxconnection": "knxjs"` against a real KNX/IP multicast setup (I don't have KNX hardware to test against; would appreciate a check from someone who does, e.g. @gartlehnerphilipp)

Fixes #186