### PR TITLE
Homebridge 2.0 compatibility (fixes #218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+- **Homebridge 2.0 compatibility** (fixes #218, based on PR #221 by @marco-hoyer):
+  - the custom `KNXThermAtHome` characteristic is now a real ES6 class; the old
+    `Characteristic.call()` + `util.inherits()` pattern threw
+    `TypeError: Class constructor cannot be invoked without 'new'`
+  - `Characteristic.Formats` / `.Perms` / `.Units` are no longer exposed by the
+    HAP library Homebridge 2.x bundles. The wire-format strings now live in
+    `lib/hapConstants.js`
+  - `getServiceByUUIDAndSubType()` was renamed to `getServiceById()`; the new
+    name is preferred, the old one is kept as a fallback
+  - `updateReachability()` was removed; the calls are now guarded
+- Homebridge 1.x keeps working: every changed call site uses feature detection
+  rather than a hard version check. Note that only Homebridge 2.x is covered by
+  the automated tests.
+- `engines` now says `node >=18` / `homebridge >=1.6.0` instead of the stale
+  `node >10.0.0` / `homebridge >=0.4.28`
+- added a smoke test suite (`npm test`) that loads the plugin against the HAP
+  library Homebridge 2.x bundles, and an eslint config (`npm run lint`). There
+  was no automated test at all before this.
+
 ## 0.4.3
 - merged PR #198 (Update WindowCoveringTilt.js) by @EyeOfTheStorm 
 - merged PR #204 (Update GarageDoorOpenerAdvanced.js) by @christof-fersch 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - `getServiceByUUIDAndSubType()` was renamed to `getServiceById()`; the new
     name is preferred, the old one is kept as a fallback
   - `updateReachability()` was removed; the calls are now guarded
+  - `Accessory.Categories` moved to the top-level `Categories` export; devices
+    with `HKCategory` set in `knx_config.json` crashed on Homebridge 2.x when
+    newly created (i.e. not restored from the accessory cache)
 - Homebridge 1.x keeps working: every changed call site uses feature detection
   rather than a hard version check. Note that only Homebridge 2.x is covered by
   the automated tests.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,53 @@
+/* jshint esversion: 6, strict: true, node: true */
+'use strict';
+
+/*
+ * Deliberately narrow: this is an ES5-era codebase and a wholesale restyle would
+ * bury real changes in noise. Lint for things that are actually broken --
+ * undefined identifiers, unreachable code, duplicate keys -- not for var vs let.
+ */
+module.exports = [
+	{
+		ignores: ['node_modules/**']
+	},
+	{
+		files: ['**/*.js'],
+		languageOptions: {
+			ecmaVersion: 2022,
+			sourceType: 'commonjs',
+			globals: {
+				require: 'readonly',
+				module: 'writable',
+				exports: 'writable',
+				process: 'readonly',
+				console: 'readonly',
+				__dirname: 'readonly',
+				__filename: 'readonly',
+				Buffer: 'readonly',
+				global: 'readonly',
+				setTimeout: 'readonly',
+				clearTimeout: 'readonly',
+				setInterval: 'readonly',
+				clearInterval: 'readonly',
+				// index.js installs this for the remote add-in loader
+				knxRequire: 'readonly'
+			}
+		},
+		linterOptions: {
+			reportUnusedDisableDirectives: true
+		},
+		rules: {
+			'no-undef': 'error',
+			'no-dupe-keys': 'error',
+			'no-dupe-args': 'error',
+			'no-duplicate-case': 'error',
+			'no-unreachable': 'error',
+			'no-func-assign': 'error',
+			'no-cond-assign': 'error',
+			'no-const-assign': 'error',
+			'no-fallthrough': 'off', // knxaccess.js relies on intentional fallthrough
+			'no-unused-vars': ['warn', { args: 'none', varsIgnorePattern: '^_' }],
+			'no-empty': ['warn', { allowEmptyCatch: true }]
+		}
+	}
+];

--- a/index.js
+++ b/index.js
@@ -161,7 +161,11 @@ KNXPlatform.prototype.configureAccessory = function (accessory) {
     // set the accessory to reachable if plugin can currently process the accessory
     // otherwise set to false and update the reachability later by invoking
     // accessory.updateReachability()
-    accessory.updateReachability(false);
+    // updateReachability() was removed in Homebridge 2.0, guard for older versions only.
+    // https://github.com/snowdd1/homebridge-knx/issues/218
+    if (typeof accessory.updateReachability === 'function') {
+        accessory.updateReachability(false);
+    }
 
     // collect the accessories
     globs.restoredAccessories.push(accessory);

--- a/lib/characteristic-knx.js
+++ b/lib/characteristic-knx.js
@@ -6,6 +6,7 @@
 
 var iterate = require('./iterate');
 var knxAccess = require('./knxaccess.js');
+var hapConstants = require('./hapConstants');
 
 /**
  * CharacteristicKNX is the wrapper for HomeKit charcteristics with everything needed for KNX use
@@ -79,7 +80,7 @@ class CharacteristicKNX {
             }
         }
         // the following types can have arrays of valid integer values
-        if (this.chr.props.format === this.globs.Characteristic.Formats.UINT8 || this.chr.props.format === this.globs.Characteristic.Formats.INT) {
+        if (this.chr.props.format === hapConstants.Formats.UINT8 || this.chr.props.format === hapConstants.Formats.INT) {
             if (this.config.ValidValues != undefined) // evil twin required for comparing with undefined
             {
                 this.chr.props.validValues = this.config.ValidValues;
@@ -91,7 +92,7 @@ class CharacteristicKNX {
 
 
         // if the characteristic is writable (that is, from homekit to the KNX bus) AND we have a Set section in the config...
-        if (this.chr.props.perms.indexOf(this.globs.Characteristic.Perms.WRITE) > -1) {
+        if (this.chr.props.perms.indexOf(hapConstants.Perms.WRITE) > -1) {
             if (this.config.Set) {
                 // add the group addresses to the set-ga list
                 // register the default handler
@@ -138,7 +139,7 @@ class CharacteristicKNX {
             }
         } // writable
         // if it is readable AND we have a listen section in the config
-        if (this.chr.props.perms.indexOf(this.globs.Characteristic.Perms.READ) > -1) {
+        if (this.chr.props.perms.indexOf(hapConstants.Perms.READ) > -1) {
             if (this.config.Listen) {
 
                 if (!Array.isArray(this.config.Listen)) {
@@ -215,33 +216,33 @@ class CharacteristicKNX {
         if (this.config.DPT) {
             return this.config.DPT;
         } else {
-            if (this.chr.props.format === this.globs.Characteristic.Formats.BOOL) {
+            if (this.chr.props.format === hapConstants.Formats.BOOL) {
                 // found boolean, assume DPT1
                 return "DPT1";
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.INT) {
+            if (this.chr.props.format === hapConstants.Formats.INT) {
                 // found INT, assume DPT5, unless props.unit is Units.PERCENTAGE
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT5";
                 }
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.UINT8) {
+            if (this.chr.props.format === hapConstants.Formats.UINT8) {
                 // found INT, assume DPT5 unless its percentage in UNIT
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT5";
                 }
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.PERCENTAGE) {
+            if (this.chr.props.format === hapConstants.Formats.PERCENTAGE) {
                 // found PERC, assume DPT5.001
                 return "DPT5.001";
             }
-            if (this.chr.props.format === this.globs.Characteristic.Formats.FLOAT) {
+            if (this.chr.props.format === hapConstants.Formats.FLOAT) {
                 // found FLOAT, assume DPT9 unless its PERCENTAGE in UNIT
-                if (this.chr.props.unit === this.globs.Characteristic.Units.PERCENTAGE) {
+                if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {
                     return "DPT5.001";
                 } else {
                     return "DPT9";

--- a/lib/characteristic-knx.js
+++ b/lib/characteristic-knx.js
@@ -236,10 +236,6 @@ class CharacteristicKNX {
                     return "DPT5";
                 }
             }
-            if (this.chr.props.format === hapConstants.Formats.PERCENTAGE) {
-                // found PERC, assume DPT5.001
-                return "DPT5.001";
-            }
             if (this.chr.props.format === hapConstants.Formats.FLOAT) {
                 // found FLOAT, assume DPT9 unless its PERCENTAGE in UNIT
                 if (this.chr.props.unit === hapConstants.Units.PERCENTAGE) {

--- a/lib/customtypes/knxthermostat.js
+++ b/lib/customtypes/knxthermostat.js
@@ -4,33 +4,38 @@
 /* jshint esversion: 6, strict: true, node: true */
 'use strict';
 
-var inherits = require('util').inherits;
+var hapConstants = require('../hapConstants');
 var log = require('debug')('KNXThermostat custom service/characteristic');
 
-/** 
+/**
  *  @param {homebridge/lib/api~API} API
  */
 module.exports = function(API) {
 
-	
+
 	// we are going to extend API.hap.Characteristic and API.hap.Service
 
 	var Characteristic = API.hap.Characteristic;
 	var Service = API.hap.Service;
 
-	Characteristic.KNXThermAtHome = function() {
-		Characteristic.call(this, 'At Home', '00001025-0000-1000-8000-0026BB765292');
-		this.setProps({
-			format : Characteristic.Formats.BOOL,
-			perms : [
-				Characteristic.Perms.READ,
-				Characteristic.Perms.WRITE,
-				Characteristic.Perms.NOTIFY ]
-		});
-		this.value = this.getDefaultValue();
-	};
-	inherits(Characteristic.KNXThermAtHome, Characteristic);
-	Characteristic.KNXThermAtHome.UUID = '00001025-0000-1000-8000-0026BB765292';
+	// newer hap-nodejs versions (Homebridge 2.0+) require ES6 class inheritance instead
+	// of the old Characteristic.call() / util.inherits() pattern.
+	// https://github.com/snowdd1/homebridge-knx/issues/218
+	class KNXThermAtHome extends Characteristic {
+		constructor() {
+			super('At Home', '00001025-0000-1000-8000-0026BB765292');
+			this.setProps({
+				format : hapConstants.Formats.BOOL,
+				perms : [
+					hapConstants.Perms.READ,
+					hapConstants.Perms.WRITE,
+					hapConstants.Perms.NOTIFY ]
+			});
+			this.value = this.getDefaultValue();
+		}
+	}
+	KNXThermAtHome.UUID = '00001025-0000-1000-8000-0026BB765292';
+	Characteristic.KNXThermAtHome = KNXThermAtHome;
 
 	log('Done');
 };

--- a/lib/groupaddress.js
+++ b/lib/groupaddress.js
@@ -1,5 +1,6 @@
 /* jshint esversion: 6, strict: true, node: true */
 'use strict';
+var hapConstants = require('./hapConstants');
 /**
  * Model for KNX group addresses
  * 
@@ -88,11 +89,11 @@ var gaComplete = function(address, globs, Characteristic){
 	// look for the address in the global group address list
 	if (!globs.config.GroupAddresses[address]) {
 		globs.log("The Group Address " + address + " is not yet defined. Type testing is not supported. Assuming match to HomeKit type");
-		if (Characteristic.props.format === globs.Characteristic.Formats.BOOL) {
+		if (Characteristic.props.format === hapConstants.Formats.BOOL) {
 			// Boolean
 			return new GroupAddress(address, 'automatically generated', DPTTypes.DPT1, true, true, true, 'INITIAL')
-		} else if (Characteristic.props.format === globs.Characteristic.Formats.INT || Characteristic.props.format === globs.Characteristic.Formats.UINT8) {
-			if (Characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+		} else if (Characteristic.props.format === hapConstants.Formats.INT || Characteristic.props.format === hapConstants.Formats.UINT8) {
+			if (Characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 				// percentage
 				return new GroupAddress(address, 'automatically generated', DPTTypes['DPT5.001'], true, true, true, 'INITIAL');
 			} else {
@@ -100,7 +101,7 @@ var gaComplete = function(address, globs, Characteristic){
 				return new GroupAddress(address, 'automatically generated', DPTTypes.DPT5, true, true, true, 'INITIAL');
 			}
 
-		} else if (Characteristic.props.format === globs.Characteristic.Formats.FLOAT) {
+		} else if (Characteristic.props.format === hapConstants.Formats.FLOAT) {
 			return new GroupAddress(address, 'automatically generated', DPTTypes.DPT9, true, true, true, 'INITIAL')
 		}
 	} else {

--- a/lib/hapConstants.js
+++ b/lib/hapConstants.js
@@ -6,6 +6,10 @@
  * are stable HAP protocol string constants, so we keep our own copy here
  * instead of depending on the Characteristic object exposing them.
  *
+ * The values below are the wire-format strings, verified against
+ * @homebridge/hap-nodejs by test/hapconstants.test.js. The key names are ours;
+ * hap-nodejs spells its read/write permissions PAIRED_READ / PAIRED_WRITE.
+ *
  * https://github.com/snowdd1/homebridge-knx/issues/218
  */
 module.exports = {
@@ -19,9 +23,7 @@ module.exports = {
 		FLOAT: 'float',
 		STRING: 'string',
 		TLV8: 'tlv8',
-		DATA: 'data',
-		ARRAY: 'array',
-		DICTIONARY: 'dictionary'
+		DATA: 'data'
 	},
 	Perms: {
 		READ: 'pr',
@@ -34,7 +36,6 @@ module.exports = {
 	},
 	Units: {
 		CELSIUS: 'celsius',
-		FAHRENHEIT: 'fahrenheit',
 		PERCENTAGE: 'percentage',
 		ARC_DEGREE: 'arcdegrees',
 		LUX: 'lux',

--- a/lib/hapConstants.js
+++ b/lib/hapConstants.js
@@ -1,0 +1,43 @@
+/* jshint esversion: 6, strict: true, node: true */
+'use strict';
+/**
+ * Newer hap-nodejs versions (bundled with Homebridge 2.0+) no longer expose
+ * Characteristic.Formats / .Perms / .Units as static properties. These values
+ * are stable HAP protocol string constants, so we keep our own copy here
+ * instead of depending on the Characteristic object exposing them.
+ *
+ * https://github.com/snowdd1/homebridge-knx/issues/218
+ */
+module.exports = {
+	Formats: {
+		BOOL: 'bool',
+		UINT8: 'uint8',
+		UINT16: 'uint16',
+		UINT32: 'uint32',
+		UINT64: 'uint64',
+		INT: 'int',
+		FLOAT: 'float',
+		STRING: 'string',
+		TLV8: 'tlv8',
+		DATA: 'data',
+		ARRAY: 'array',
+		DICTIONARY: 'dictionary'
+	},
+	Perms: {
+		READ: 'pr',
+		WRITE: 'pw',
+		NOTIFY: 'ev',
+		HIDDEN: 'hd',
+		ADDITIONAL_AUTHORIZATION: 'aa',
+		WRITE_RESPONSE: 'wr',
+		TIMED_WRITE: 'tw'
+	},
+	Units: {
+		CELSIUS: 'celsius',
+		FAHRENHEIT: 'fahrenheit',
+		PERCENTAGE: 'percentage',
+		ARC_DEGREE: 'arcdegrees',
+		LUX: 'lux',
+		SECONDS: 'seconds'
+	}
+};

--- a/lib/knxaccess.js
+++ b/lib/knxaccess.js
@@ -10,6 +10,7 @@ var globs;
 var knx  = require('knx');
 var knxd = require('eibd');
 var iterate = require('./iterate');
+var hapConstants = require('./hapConstants');
 var allFunctions =  {};
 // all purpose / all types write function	
 
@@ -321,20 +322,20 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		TLV8: 'tlv8'
 		}
 	 */
-	case globs.Characteristic.Formats.BOOL:
+	case hapConstants.Formats.BOOL:
 		// boolean is good for any trueish expression from value
 		globs.debug("BOOL:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type );
 		//characteristic.setValue(val ? (reverse ? 0 : 1) : (reverse ? 1 : 0), undefined, 'fromKNXBus');
 		returnValue = val ? (reverse ? 0 : 1) : (reverse ? 1 : 0);
 		break;
-	case globs.Characteristic.Formats.INT:
+	case hapConstants.Formats.INT:
 		// let fall through
-	case globs.Characteristic.Formats.UINT8:
+	case hapConstants.Formats.UINT8:
 		// let fall through
-	case globs.Characteristic.Formats.UINT16:
+	case hapConstants.Formats.UINT16:
 		// let fall through 
 		//fixes #123 
-	case globs.Characteristic.Formats.UINT32:
+	case hapConstants.Formats.UINT32:
 		// fixes #123
 		// to an INT we can assume that the min and max values are set, or a list of allowed values is supplied
 		globs.debug("INT:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type );
@@ -351,7 +352,7 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		} else {
 
 			// we have a defined range. If it's a percentage, we want to convert the bus value to the spectrum
-			if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+			if (characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 				if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
 					if (type === 'DPT5') {
 						val = reverse ? (255 - val) : val;
@@ -375,12 +376,12 @@ allFunctions.writeValueHK = function(val, chrKNX, type, reverse) {
 		}
 
 		break;
-	case globs.Characteristic.Formats.FLOAT:
+	case hapConstants.Formats.FLOAT:
 		globs.debug("FLOAT:[" + characteristic.displayName + "]: Received value from KNX handler:" + val + " of type " + type + " for " +
 				characteristic.displayName);
 
 		// If it's a percentage, we want to convert the bus value to the spectrum
-		if (characteristic.props.unit === globs.Characteristic.Units.PERCENTAGE) {
+		if (characteristic.props.unit === hapConstants.Units.PERCENTAGE) {
 			if (!(!globs.knxconnection) || globs.knxconnection === 'knxjs') {
 				if (type === 'DPT5') {
 					val = reverse ? (255 - val) : val;

--- a/lib/knxdevice.js
+++ b/lib/knxdevice.js
@@ -127,7 +127,11 @@ class KNXDevice {
 			globs.API.registerPlatformAccessories("homebridge-knx", "KNX", [this.platformAccessory]);
 		} // if
 		// otherwise we were fine before.
-		this.platformAccessory.updateReachability(true);
+		// updateReachability() was removed in Homebridge 2.0, guard for older versions only.
+		// https://github.com/snowdd1/homebridge-knx/issues/218
+		if (typeof this.platformAccessory.updateReachability === 'function') {
+			this.platformAccessory.updateReachability(true);
+		}
 	} // constructor
 	
 	/**

--- a/lib/knxdevice.js
+++ b/lib/knxdevice.js
@@ -55,7 +55,8 @@ class KNXDevice {
 			this.platformAccessory = new globs.API.platformAccessory(
 					this.name, // displayName property 
 					(this.config.UUID), // UUID property - must not change later on 
-					((config.HKCategory) ? globs.API.hap.Accessory.Categories[config.HKCategory] : undefined) // Category if present in in the config  
+					// Accessory.Categories moved to the top-level Categories export in Homebridge 2.0 (issue #218)
+					((config.HKCategory) ? (globs.API.hap.Categories || globs.API.hap.Accessory.Categories)[config.HKCategory] : undefined) // Category if present in in the config
 			);
 			//this.platformAccessory.context.ID = this.config.context;
 			// Test context:

--- a/lib/service-knx.js
+++ b/lib/service-knx.js
@@ -111,8 +111,14 @@ class ServiceKNX {
 		}
 
 		// try to find it.
+		// Homebridge 2.0+ renamed getServiceByUUIDAndSubType() to getServiceById().
+		// https://github.com/snowdd1/homebridge-knx/issues/218
 		/** @type {Service} */
-		this.serviceHK = platformAccessory.getServiceByUUIDAndSubType(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		if (platformAccessory.getServiceById) {
+			this.serviceHK = platformAccessory.getServiceById(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		} else {
+			this.serviceHK = platformAccessory.getServiceByUUIDAndSubType(this.Services[this.config.ServiceType], this.config.subtype); //we use the constructor instead of the UUID string.
+		}
 
 
 		if (!this.serviceHK) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1581 @@
+{
+    "name": "homebridge-knx",
+    "version": "0.4.3",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "homebridge-knx",
+            "version": "0.4.3",
+            "license": "GPL-2.0",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "eibd": "^0.5.1",
+                "knx": "^2.5.2"
+            },
+            "devDependencies": {
+                "@homebridge/hap-nodejs": "^2.1.7",
+                "eslint": "^9.39.4"
+            },
+            "engines": {
+                "homebridge": ">=1.6.0",
+                "node": ">=18"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.1",
+                "minimatch": "^3.1.5",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@homebridge/ciao": {
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.10.tgz",
+            "integrity": "sha512-ogAVdPZ9Fo3kSaULpq+acxbtbIvMtd2TDYEkqHIsqvQ9QHJnRNcjm8NQzegaBzJ3gUK1mVX07UWs2/B0NmabSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "fast-deep-equal": "^3.1.3",
+                "source-map-support": "^0.5.21",
+                "tslib": "^2.8.1"
+            },
+            "bin": {
+                "ciao-bcs": "lib/bonjour-conformance-testing.js"
+            }
+        },
+        "node_modules/@homebridge/dbus-native": {
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.7.tgz",
+            "integrity": "sha512-VwTSCy1qofS0QLHtOiSVVmtR49xr/DR17D+5VeJm+xw1rGaluv++MF/atF1Jomxsf4WduVed63ouX2s6SH17Qw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "event-stream": "^4.0.1",
+                "hexy": "^0.4.0",
+                "long": "^5.3.2",
+                "minimist": "^1.2.8",
+                "safe-buffer": "^5.1.2",
+                "xml2js": "^0.6.2"
+            },
+            "bin": {
+                "dbus2js": "bin/dbus2js.js"
+            }
+        },
+        "node_modules/@homebridge/hap-nodejs": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.7.tgz",
+            "integrity": "sha512-0SiNVc0OCkFN0figsOg7fWcEe/3OLF58sUyE8kzrQ+BoINkSEHz824xzKHep/yOT7SJtd2FREbFsQklkF/Kn2g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@homebridge/ciao": "^1.3.9",
+                "@homebridge/dbus-native": "^0.7.6",
+                "bonjour-hap": "^3.10.3",
+                "debug": "^4.4.3",
+                "fast-srp-hap": "^2.0.4",
+                "futoin-hkdf": "^1.5.3",
+                "node-persist": "^0.0.12",
+                "source-map-support": "^0.5.21",
+                "tslib": "^2.8.1",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": "^22 || ^24"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "6.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.13.tgz",
+            "integrity": "sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw==",
+            "license": "MIT"
+        },
+        "node_modules/acorn": {
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/binary-parser": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-1.1.5.tgz",
+            "integrity": "sha512-KsW0sfQ3e5Lpk8EVP44okdpOUhUlVaQ5HQ/qBKLpuMgEV29pTIfPvFobs9j4kp/4BqOSZ+kZpC7f4mleVonTRw==",
+            "license": "MIT"
+        },
+        "node_modules/binary-protocol": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/binary-protocol/-/binary-protocol-0.0.0.tgz",
+            "integrity": "sha512-kcFqbqtZnZEGSY8Jh6dEO6VbxJDZu1tqJc3LODqADPHrDwHQwoTNdGTHW4sLhmNXeWUOZKjfRfopAu5xpRQbPw==",
+            "license": "MIT",
+            "dependencies": {
+                "bluebird": "~2.2.2"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
+            "integrity": "sha512-NqzuS2y44FmP++Ihv6/PgXpNRB+c282TKq0URBTQdA+EqPpR1Qu44QY8H8667LA39iOIaVHpmRPI4gpthYT8Ug==",
+            "license": "MIT"
+        },
+        "node_modules/bonjour-hap": {
+            "version": "3.10.4",
+            "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.4.tgz",
+            "integrity": "sha512-300Ay6OMOeE0TGVimI1UuPMbmagMPcA8qR4c77YWY8M6cs7Skedu6Bhx5pcMQi1K1HUUdzTv3Rs4GD/OWxgdEw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5",
+                "multicast-dns-service-types": "^1.1.0"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dns-packet": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eibd": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/eibd/-/eibd-0.5.1.tgz",
+            "integrity": "sha512-S3eEhQqy94trPUZusL/BF9eFFV3WzrqKoBv3wpb6mTkfhhUAfcdNzZbqfrY0DpYmf5ArRuvXkjJ+7Tv3IJOTbQ==",
+            "bin": {
+                "groupread": "bin/groupread",
+                "groupsend": "bin/groupsend",
+                "groupsocketlisten": "bin/groupsocketlisten",
+                "groupswrite": "bin/groupswrite",
+                "groupwrite": "bin/groupwrite"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.5",
+                "@eslint/js": "9.39.4",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.5",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/event-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+            "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "^0.1.1",
+                "from": "^0.1.7",
+                "map-stream": "0.0.7",
+                "pause-stream": "^0.0.11",
+                "split": "^1.0.1",
+                "stream-combiner": "^0.2.2",
+                "through": "^2.3.8"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-srp-hap": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
+            "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/futoin-hkdf": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
+            "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/hexy": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+            "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "hexy": "bin/hexy_cmd.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+            "integrity": "sha512-ku//LD7ie/m9UVGCm9KweBIIHP4mB0maNGvav6Hz778fQCNLQF7iZ+H/UuHuqmjJCHCpA5hw8hOeRKxZl8IlXw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/knx": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/knx/-/knx-2.5.4.tgz",
+            "integrity": "sha512-h+WMbx2NPgCL1Vr4X8xAsTV9E+72XjPviKRv67iJLomapENO25ZsRGq8egvqUJwtnsordJGOxxUA4o1jMOzQYw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "^6.14.4",
+                "binary-parser": "1.1.5",
+                "binary-protocol": "0.0.0",
+                "ipaddr.js": "1.2.0",
+                "log-driver": "1.2.7",
+                "machina": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/log-driver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=0.8.6"
+            }
+        },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/machina": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/machina/-/machina-4.0.2.tgz",
+            "integrity": "sha512-OOlFrW1rd783S6tF36v5Ie/TM64gfvSl9kYLWL2cPA31J71HHWW3XrgSe1BZSFAPkh8532CMJMLv/s9L2aopiA==",
+            "dependencies": {
+                "lodash": "^4.17.5"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/map-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/multicast-dns": {
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dns-packet": "^5.2.2",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
+        },
+        "node_modules/multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-persist": {
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+            "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mkdirp": "~0.5.1",
+                "q": "~1.1.1"
+            }
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "dev": true,
+            "license": [
+                "MIT",
+                "Apache2"
+            ],
+            "dependencies": {
+                "through": "~2.3"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/q": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+            "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
+            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.0",
+                "teleport": ">=0.2.0"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/stream-combiner": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "through": "~2.3.4"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/tweetnacl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+            "dev": true,
+            "license": "Unlicense"
+        },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-knx",
-    "version": "0.4.3",
+    "version": "0.5.0-rc.1",
     "description": "homebridge shim for KNX home automation.",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "homebridge shim for KNX home automation.",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "node --test test/*.test.js",
+        "lint": "eslint .",
         "start": "echo \"Error: configure and run homebridge to start\" && exit 1"
     },
     "engines": {
@@ -77,5 +78,9 @@
     "bugs": {
         "url": "https://github.com/snowdd1/homebridge-knx/issues"
     },
-    "homepage": "https://github.com/snowdd1/homebridge-knx"
+    "homepage": "https://github.com/snowdd1/homebridge-knx",
+    "devDependencies": {
+        "@homebridge/hap-nodejs": "^2.1.7",
+        "eslint": "^9.39.4"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
         "start": "echo \"Error: configure and run homebridge to start\" && exit 1"
     },
     "engines": {
-        "node": ">10.0.0",
-        "homebridge": ">=0.4.28"
+        "node": ">=18",
+        "homebridge": ">=1.6.0"
     },
     "repository": {
         "type": "git",

--- a/test/hapconstants.test.js
+++ b/test/hapconstants.test.js
@@ -1,0 +1,56 @@
+/* jshint esversion: 6, strict: true, node: true */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const hap = require('@homebridge/hap-nodejs');
+const hapConstants = require('../lib/hapConstants.js');
+
+/*
+ * lib/hapConstants.js hardcodes the HAP wire-format strings because Homebridge
+ * 2.0 stopped exposing them on the Characteristic object. Hardcoding is only
+ * safe as long as the values cannot silently drift away from hap-nodejs, so
+ * pin them here.
+ *
+ * Only the values are contractual. The key names are ours: hap-nodejs calls its
+ * read/write permissions PAIRED_READ / PAIRED_WRITE, we call them READ / WRITE.
+ */
+test('every hapConstants value exists in the corresponding hap-nodejs export', () => {
+	for (const group of ['Formats', 'Perms', 'Units']) {
+		const known = Object.values(hap[group]);
+		for (const [name, value] of Object.entries(hapConstants[group])) {
+			assert.ok(
+				known.includes(value),
+				`hapConstants.${group}.${name} = ${JSON.stringify(value)} is not a value of hap.${group}`
+			);
+		}
+	}
+});
+
+// The constants the plugin actually branches on. If hap-nodejs ever renames one
+// of these values, the plugin silently stops recognising the type, so assert the
+// exact mapping rather than mere membership.
+test('constants used by the plugin match hap-nodejs exactly', () => {
+	assert.strictEqual(hapConstants.Formats.BOOL, hap.Formats.BOOL);
+	assert.strictEqual(hapConstants.Formats.INT, hap.Formats.INT);
+	assert.strictEqual(hapConstants.Formats.UINT8, hap.Formats.UINT8);
+	assert.strictEqual(hapConstants.Formats.UINT16, hap.Formats.UINT16);
+	assert.strictEqual(hapConstants.Formats.UINT32, hap.Formats.UINT32);
+	assert.strictEqual(hapConstants.Formats.FLOAT, hap.Formats.FLOAT);
+
+	assert.strictEqual(hapConstants.Perms.READ, hap.Perms.PAIRED_READ);
+	assert.strictEqual(hapConstants.Perms.WRITE, hap.Perms.PAIRED_WRITE);
+	assert.strictEqual(hapConstants.Perms.NOTIFY, hap.Perms.NOTIFY);
+
+	assert.strictEqual(hapConstants.Units.PERCENTAGE, hap.Units.PERCENTAGE);
+});
+
+// Guards the reason this module exists: reading the constants off Characteristic
+// yields undefined on Homebridge 2.x. If a future hap-nodejs restores them, we
+// can drop hapConstants -- this test tells us when that happens.
+test('Characteristic no longer exposes Formats/Perms/Units', () => {
+	assert.strictEqual(hap.Characteristic.Formats, undefined);
+	assert.strictEqual(hap.Characteristic.Perms, undefined);
+	assert.strictEqual(hap.Characteristic.Units, undefined);
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,81 @@
+/* jshint esversion: 6, strict: true, node: true */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const hap = require('@homebridge/hap-nodejs');
+
+/*
+ * The plugin cannot run without Homebridge and a KNX daemon, but its entry point
+ * -- registry(api) -- runs plain JavaScript against the HAP type library. That
+ * is exactly where Homebridge 2.0 used to blow up (issue #218), so drive it here
+ * against the real @homebridge/hap-nodejs that Homebridge 2.x bundles.
+ *
+ * No KNX connection is opened: registry() only registers types and the platform
+ * constructor. The constructor itself, which talks to the bus, is never invoked.
+ */
+function makeApiMock() {
+	const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'homebridge-knx-test-'));
+	const registered = [];
+	return {
+		registered,
+		api: {
+			version: 2.7,
+			hap,
+			user: { storagePath: () => storagePath },
+			registerPlatform: (pluginName, platformName, constructor, dynamic) => {
+				registered.push({ pluginName, platformName, constructor, dynamic });
+			},
+			on: () => {}
+		}
+	};
+}
+
+test('plugin entry point loads without throwing', () => {
+	const registry = require('../index.js');
+	assert.strictEqual(typeof registry, 'function');
+});
+
+test('registry() runs against Homebridge 2.x hap-nodejs and registers the platform', () => {
+	const registry = require('../index.js');
+	const { api, registered } = makeApiMock();
+
+	registry(api);
+
+	assert.strictEqual(registered.length, 1, 'expected exactly one registerPlatform call');
+	assert.strictEqual(registered[0].pluginName, 'homebridge-knx');
+	assert.strictEqual(registered[0].platformName, 'KNX');
+	assert.strictEqual(registered[0].dynamic, true, 'platform must register as dynamic');
+});
+
+// Regression test for the ES5 Characteristic.call() + util.inherits() pattern,
+// which throws "Class constructor cannot be invoked without 'new'" on HB 2.0.
+test('custom KNXThermAtHome characteristic instantiates on Homebridge 2.x', () => {
+	const registry = require('../index.js');
+	const { api } = makeApiMock();
+	registry(api);
+
+	const KNXThermAtHome = hap.Characteristic.KNXThermAtHome;
+	assert.ok(KNXThermAtHome, 'KNXThermAtHome was not registered on Characteristic');
+
+	const chr = new KNXThermAtHome();
+	assert.ok(chr instanceof hap.Characteristic, 'must be a real Characteristic');
+	assert.strictEqual(chr.props.format, hap.Formats.BOOL);
+	assert.deepStrictEqual(
+		[...chr.props.perms].sort(),
+		[hap.Perms.PAIRED_READ, hap.Perms.PAIRED_WRITE, hap.Perms.NOTIFY].sort()
+	);
+	assert.strictEqual(KNXThermAtHome.UUID, '00001025-0000-1000-8000-0026BB765292');
+});
+
+// Homebridge 2.0 renamed getServiceByUUIDAndSubType() to getServiceById().
+// service-knx.js must prefer the new name but still work on Homebridge 1.x.
+test('service lookup prefers getServiceById and falls back to the old name', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'lib', 'service-knx.js'), 'utf8');
+	assert.match(source, /platformAccessory\.getServiceById/, 'must call getServiceById');
+	assert.match(source, /getServiceByUUIDAndSubType/, 'must keep the Homebridge 1.x fallback');
+});


### PR DESCRIPTION
## Summary

This makes homebridge-knx compatible with Homebridge 2.x at the source level, replacing the runtime `sed`/`tee` patches discussed in #218. It builds on the baseline from #218 and PR #221 by @marco-hoyer.

Fixes #218.

### Homebridge 2.0 breaking changes addressed

- **ES6 class enforcement:** the custom `KNXThermAtHome` characteristic is now a real `class … extends Characteristic`; the old `Characteristic.call()` + `util.inherits()` pattern threw `TypeError: Class constructor cannot be invoked without 'new'`.
- **`Characteristic.Formats` / `.Perms` / `.Units` removed:** the HAP wire-format strings now live in `lib/hapConstants.js` and are used everywhere those enums were read.
- **`getServiceByUUIDAndSubType()` renamed:** `getServiceById()` is preferred, the old name is kept as a fallback.
- **`updateReachability()` removed:** the calls are now guarded.
- **`Accessory.Categories` moved** to the top-level `Categories` export; devices with `HKCategory` set in `knx_config.json` crashed on Homebridge 2.x when newly created (not restored from the accessory cache).

### Compatibility

Homebridge 1.x keeps working: every changed call site uses feature detection rather than a hard version check. `engines` is updated to `node >=18` / `homebridge >=1.6.0` (was `node >10.0.0` / `homebridge >=0.4.28`).

### Tooling added

- A smoke test suite (`npm test`) that loads the plugin against `@homebridge/hap-nodejs` (the HAP library Homebridge 2.x bundles) — there was no automated test before.
- An eslint config (`npm run lint`).

### Testing

- `npm test` passes against `@homebridge/hap-nodejs` 2.x.
- Running live since 2026-07-10 on a Raspberry Pi with Homebridge v2.1.0 (HAP v2.1.7) against a real KNX installation (11 devices via knxd): accessories restore from cache correctly, reads and writes work.

Version is bumped to `0.5.0-rc.1` so a test install is distinguishable from the published `0.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
